### PR TITLE
snapcraft.yaml: bump version to 25.07.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,7 @@ parts:
     plugin: rust
     rust-path: [helix-term]
     source: https://github.com/helix-editor/helix.git
-    source-tag: "25.01.1"
+    source-tag: "25.07.1"
     override-pull: |
       craftctl default
       craftctl set version="$(git describe --tags --always)"


### PR DESCRIPTION
Helix 25.07 (and a consequent patch release 25.07.1) has just been released.
This updates the helix snap package with the latest version.